### PR TITLE
fix(rbpf): Exclude std feature from no_std build

### DIFF
--- a/rbpf/src/elf_parser_glue.rs
+++ b/rbpf/src/elf_parser_glue.rs
@@ -546,6 +546,7 @@ impl From<GoblinError> for ElfError {
             GoblinError::Malformed(string) => Self::FailedToParse(format!("malformed: {string}")),
             GoblinError::BadMagic(magic) => Self::FailedToParse(format!("bad magic: {magic:#x}")),
             GoblinError::Scroll(error) => Self::FailedToParse(format!("read-write: {error}")),
+            #[cfg(feature = "std")]
             GoblinError::IO(error) => Self::FailedToParse(format!("io: {error}")),
             GoblinError::BufferTooShort(n, error) => {
                 Self::FailedToParse(format!("buffer too short {n} {error}"))


### PR DESCRIPTION
The `goblin::error::Error::IO` variant is only available in the `std` context. This PR removes the use of `IO` variant from pattern matching to fix error when building `solana_rbpf` in a `no_std` environment. 