### PR TITLE
chore(program): Exclude wasm module in `no_std`

### DIFF
--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -538,6 +538,7 @@ pub mod system_instruction;
 pub mod system_program;
 pub mod sysvar;
 pub mod vote;
+#[cfg(feature = "std")]
 pub mod wasm;
 
 #[cfg(target_arch = "wasm32")]


### PR DESCRIPTION
This PR excludes `wasm` module from `solana-program` when `std` feature is disabled.