### PR TITLE
feat: Add feature gate for optional wasm-bindgen integration

### DIFF
--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -79,6 +79,12 @@ scale = [
   "scale-info",
   "solana-program/scale",
 ]
+wasm-bindgen = [
+  "dep:wasm-bindgen",
+  "getrandom",
+  "js-sys",
+  "solana-program/wasm-bindgen",
+]
 
 [dependencies]
 bincode = { workspace = true }
@@ -126,9 +132,9 @@ thiserror = { workspace = true }
 uriparse = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-getrandom = { version = "0.1", features = ["wasm-bindgen"] }
-js-sys = { workspace = true }
-wasm-bindgen = { workspace = true }
+getrandom = { version = "0.1", features = ["wasm-bindgen"], optional = true }
+js-sys = { workspace = true, optional = true }
+wasm-bindgen = { workspace = true, optional = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -58,21 +58,21 @@ ark-serialize = { workspace = true, default-features = true }
 base64 = { workspace = true, features = ["alloc", "std"] }
 bitflags = { workspace = true, default-features = true }
 curve25519-dalek = { workspace = true }
-libsecp256k1 = { workspace = true, default-features = true }
+libsecp256k1 = { workspace = true, features = ["static-context"] }
 num-bigint = { workspace = true, default-features = true }
 rand = { workspace = true }
 
 [target.'cfg(not(target_os = "solana"))'.dev-dependencies]
 arbitrary = { workspace = true, features = ["derive"] }
-libsecp256k1 = { workspace = true, features = ["hmac"] } # used by doctests
+#libsecp256k1 = { workspace = true, features = ["hmac"] } # used by doctests
 solana-logger = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-console_error_panic_hook = { workspace = true }
-console_log = { workspace = true }
-getrandom = { workspace = true, features = ["js", "wasm-bindgen"] }
-js-sys = { workspace = true }
-wasm-bindgen = { workspace = true }
+console_error_panic_hook = { workspace = true, optional = true }
+console_log = { workspace = true, optional = true }
+getrandom = { workspace = true, features = ["js", "wasm-bindgen"], optional = true }
+js-sys = { workspace = true, optional = true }
+wasm-bindgen = { workspace = true, optional = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
@@ -101,6 +101,7 @@ std = [
   "bs58/std",
   "bv/std",
   "itertools/use_std",
+  "libsecp256k1/default",
   "log/std",
   "nostd/std",
   "num-traits/std",
@@ -116,3 +117,10 @@ borsh = ["dep:borsh", "dep:borsh0-10"]
 dev-context-only-utils = ["dep:qualifier_attr"]
 frozen-abi = ["dep:solana-frozen-abi", "dep:solana-frozen-abi-macro"]
 scale = ["parity-scale-codec", "scale-info"]
+wasm-bindgen = [
+  "dep:wasm-bindgen",
+  "console_error_panic_hook",
+  "console_log",
+  "getrandom",
+  "js-sys",
+]

--- a/sdk/program/src/hash.rs
+++ b/sdk/program/src/hash.rs
@@ -3,7 +3,7 @@
 //! [SHA-256]: https://en.wikipedia.org/wiki/SHA-2
 //! [`Hash`]: struct@Hash
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "wasm-bindgen")]
 use crate::wasm_bindgen;
 use {
     crate::sanitize::Sanitize,
@@ -38,7 +38,7 @@ const MAX_BASE58_LEN: usize = 44;
 /// [blake3]: https://github.com/BLAKE3-team/BLAKE3
 /// [`blake3`]: crate::blake3
 /// [`Message::hash`]: crate::message::Message::hash
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[cfg_attr(
     feature = "borsh",

--- a/sdk/program/src/instruction.rs
+++ b/sdk/program/src/instruction.rs
@@ -13,7 +13,7 @@
 
 #![allow(clippy::arithmetic_side_effects)]
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "wasm-bindgen")]
 use crate::wasm_bindgen;
 #[cfg(feature = "borsh")]
 use borsh::BorshSerialize;
@@ -333,7 +333,7 @@ pub enum InstructionError {
 /// Programs may require signatures from some accounts, in which case they
 /// should be specified as signers during `Instruction` construction. The
 /// program must still validate during execution that the account is a signer.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(feature = "wasm-bindgen"))]
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct Instruction {
     /// Pubkey of the program that executes this instruction.
@@ -347,7 +347,7 @@ pub struct Instruction {
 /// wasm-bindgen version of the Instruction struct.
 /// This duplication is required until https://github.com/rustwasm/wasm-bindgen/issues/3671
 /// is fixed. This must not diverge from the regular non-wasm Instruction struct.
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "wasm-bindgen")]
 #[wasm_bindgen]
 pub struct Instruction {
     #[wasm_bindgen(skip)]

--- a/sdk/program/src/lib.rs
+++ b/sdk/program/src/lib.rs
@@ -538,10 +538,10 @@ pub mod system_instruction;
 pub mod system_program;
 pub mod sysvar;
 pub mod vote;
-#[cfg(feature = "std")]
+#[cfg(feature = "wasm-bindgen")]
 pub mod wasm;
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "wasm-bindgen")]
 pub use wasm_bindgen::prelude::wasm_bindgen;
 
 /// The [config native program][np].

--- a/sdk/program/src/message/legacy.rs
+++ b/sdk/program/src/message/legacy.rs
@@ -11,7 +11,7 @@
 
 #![allow(clippy::arithmetic_side_effects)]
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "wasm-bindgen")]
 use crate::wasm_bindgen;
 #[allow(deprecated)]
 pub use builtins::{BUILTIN_PROGRAMS_KEYS, MAYBE_BUILTIN_KEY_OR_SYSVAR};
@@ -123,7 +123,7 @@ fn compile_instructions(ixs: &[Instruction], keys: &[Pubkey]) -> Vec<CompiledIns
 /// redundantly specifying the fee-payer is not strictly required.
 // NOTE: Serialization-related changes must be paired with the custom serialization
 // for versioned messages in the `RemainingLegacyMessage` struct.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(feature = "wasm-bindgen"))]
 #[cfg_attr(
     feature = "frozen-abi",
     frozen_abi(digest = "2KnLEqfLcTBQqitE22Pp8JYkaqVVbAkGbCfdeHoyxcAU"),
@@ -153,13 +153,14 @@ pub struct Message {
 /// wasm-bindgen version of the Message struct.
 /// This duplication is required until https://github.com/rustwasm/wasm-bindgen/issues/3671
 /// is fixed. This must not diverge from the regular non-wasm Message struct.
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "wasm-bindgen")]
 #[wasm_bindgen]
 #[cfg_attr(
     feature = "frozen-abi",
     frozen_abi(digest = "2KnLEqfLcTBQqitE22Pp8JYkaqVVbAkGbCfdeHoyxcAU"),
     derive(AbiExample)
 )]
+#[cfg_attr(feature = "scale", derive(Decode, Encode, TypeInfo))]
 #[derive(Serialize, Deserialize, Default, Debug, PartialEq, Eq, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct Message {

--- a/sdk/program/src/pubkey.rs
+++ b/sdk/program/src/pubkey.rs
@@ -2,7 +2,7 @@
 
 #![allow(clippy::arithmetic_side_effects)]
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "wasm-bindgen")]
 use crate::wasm_bindgen;
 #[cfg(test)]
 use arbitrary::Arbitrary;
@@ -71,7 +71,7 @@ impl From<u64> for PubkeyError {
 /// [ed25519]: https://ed25519.cr.yp.to/
 /// [pdas]: https://solana.com/docs/core/cpi#program-derived-addresses
 /// [`Keypair`]: https://docs.rs/solana-sdk/latest/solana_sdk/signer/keypair/struct.Keypair.html
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 #[repr(transparent)]
 #[cfg_attr(feature = "frozen-abi", derive(AbiExample))]
 #[cfg_attr(

--- a/sdk/program/src/wasm/hash.rs
+++ b/sdk/program/src/wasm/hash.rs
@@ -1,5 +1,5 @@
 //! `Hash` Javascript interface
-#![cfg(target_arch = "wasm32")]
+#![cfg(feature = "wasm-bindgen")]
 #![allow(non_snake_case)]
 use {
     crate::{hash::*, wasm::display_to_jsvalue},

--- a/sdk/program/src/wasm/instructions.rs
+++ b/sdk/program/src/wasm/instructions.rs
@@ -1,6 +1,6 @@
 //! The `Instructions` struct is a workaround for the lack of Vec<T> support in wasm-bindgen
 //! (ref: https://github.com/rustwasm/wasm-bindgen/issues/111)
-#![cfg(target_arch = "wasm32")]
+#![cfg(feature = "wasm-bindgen")]
 use {crate::instruction::Instruction, wasm_bindgen::prelude::*};
 
 #[wasm_bindgen]

--- a/sdk/program/src/wasm/mod.rs
+++ b/sdk/program/src/wasm/mod.rs
@@ -1,5 +1,5 @@
 //! solana-program Javascript interface
-#![cfg(target_arch = "wasm32")]
+#![cfg(feature = "wasm-bindgen")]
 use wasm_bindgen::prelude::*;
 
 pub mod hash;

--- a/sdk/program/src/wasm/pubkey.rs
+++ b/sdk/program/src/wasm/pubkey.rs
@@ -1,5 +1,5 @@
 //! `Pubkey` Javascript interface
-#![cfg(target_arch = "wasm32")]
+#![cfg(feature = "wasm-bindgen")]
 #![allow(non_snake_case)]
 use {
     crate::{pubkey::*, wasm::display_to_jsvalue},

--- a/sdk/program/src/wasm/system_instruction.rs
+++ b/sdk/program/src/wasm/system_instruction.rs
@@ -1,5 +1,5 @@
 //! `SystemInstruction` Javascript interface
-#![cfg(target_arch = "wasm32")]
+#![cfg(feature = "wasm-bindgen")]
 #![allow(non_snake_case)]
 use {
     crate::{instruction::Instruction, pubkey::Pubkey, system_instruction::*},

--- a/sdk/src/lib.rs
+++ b/sdk/src/lib.rs
@@ -46,7 +46,7 @@ pub use solana_program::program_stubs;
 // confusing duplication in the docs due to a rustdoc bug. #26211
 #[allow(deprecated)]
 pub use solana_program::sdk_ids;
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "wasm-bindgen")]
 pub use solana_program::wasm_bindgen;
 pub use solana_program::{
     account_info, address_lookup_table, alt_bn128, big_mod_exp, blake3, bpf_loader,

--- a/sdk/src/signer/keypair.rs
+++ b/sdk/src/signer/keypair.rs
@@ -2,7 +2,7 @@
 
 #[cfg(feature = "std")]
 use std::path::Path;
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "wasm-bindgen")]
 use wasm_bindgen::prelude::*;
 use {
     crate::{
@@ -23,7 +23,7 @@ use {
 };
 
 /// A vanilla Ed25519 key pair
-#[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
+#[cfg_attr(feature = "wasm-bindgen", wasm_bindgen)]
 #[derive(Debug)]
 pub struct Keypair(ed25519_dalek::Keypair);
 

--- a/sdk/src/transaction/mod.rs
+++ b/sdk/src/transaction/mod.rs
@@ -111,7 +111,7 @@
 
 #![cfg(feature = "full")]
 
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "wasm-bindgen")]
 use crate::wasm_bindgen;
 use {
     crate::{
@@ -168,7 +168,7 @@ pub type Result<T> = result::Result<T, TransactionError>;
 /// if the caller has knowledge that the first account of the constructed
 /// transaction's `Message` is both a signer and the expected fee-payer, then
 /// redundantly specifying the fee-payer is not strictly required.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(not(feature = "wasm-bindgen"))]
 #[cfg_attr(
     feature = "frozen-abi",
     derive(AbiExample),
@@ -195,7 +195,7 @@ pub struct Transaction {
 /// wasm-bindgen version of the Transaction struct.
 /// This duplication is required until https://github.com/rustwasm/wasm-bindgen/issues/3671
 /// is fixed. This must not diverge from the regular non-wasm Transaction struct.
-#[cfg(target_arch = "wasm32")]
+#[cfg(feature = "wasm-bindgen")]
 #[wasm_bindgen]
 #[cfg_attr(
     feature = "frozen-abi",

--- a/sdk/src/wasm/keypair.rs
+++ b/sdk/src/wasm/keypair.rs
@@ -1,5 +1,5 @@
 //! `Keypair` Javascript interface
-#![cfg(target_arch = "wasm32")]
+#![cfg(feature = "wasm-bindgen")]
 #![allow(non_snake_case)]
 use {
     crate::signer::{keypair::Keypair, Signer},

--- a/sdk/src/wasm/mod.rs
+++ b/sdk/src/wasm/mod.rs
@@ -1,5 +1,5 @@
 //! solana-sdk Javascript interface
-#![cfg(target_arch = "wasm32")]
+#![cfg(feature = "wasm-bindgen")]
 
 pub mod keypair;
 pub mod transaction;

--- a/sdk/src/wasm/transaction.rs
+++ b/sdk/src/wasm/transaction.rs
@@ -1,5 +1,5 @@
 //! `Transaction` Javascript interface
-#![cfg(target_arch = "wasm32")]
+#![cfg(feature = "wasm-bindgen")]
 #![allow(non_snake_case)]
 use {
     crate::{hash::Hash, message::Message, signer::keypair::Keypair, transaction::Transaction},


### PR DESCRIPTION
This PR adds the feature gate to `wasm-bindgen` integration configurable.