### PR TITLE
fix: Exclude create_genesis_config from no_std

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Build
         run: cargo build -v
+      - name: Build no_std
+        run: cargo build --no-default-features --features full,scale -v
   test:
     runs-on: ubuntu-22.04
     steps:

--- a/sdk/src/genesis_config.rs
+++ b/sdk/src/genesis_config.rs
@@ -15,8 +15,6 @@ use {
         pubkey::Pubkey,
         rent::Rent,
         shred_version::compute_shred_version,
-        signature::{Keypair, Signer},
-        system_program,
         timing::years_as_slots,
     },
     bincode::serialize,
@@ -25,6 +23,10 @@ use {
 };
 #[cfg(feature = "std")]
 use {
+    crate::{
+        signature::{Keypair, Signer},
+        system_program,
+    },
     bincode::deserialize,
     memmap2::Mmap,
     std::{
@@ -121,6 +123,7 @@ pub struct GenesisConfig {
 }
 
 // useful for basic tests
+#[cfg(feature = "std")]
 pub fn create_genesis_config(lamports: u64) -> (GenesisConfig, Keypair) {
     let faucet_keypair = Keypair::new();
     (


### PR DESCRIPTION
This PR removes `create_genesis_config()` from `no_std` build.