### PR TITLE
ci: Skip unnecessary installation of protoc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: arduino/setup-protoc@v3
       - run: rustup show
       - uses: Swatinem/rust-cache@v2
       - name: Check
@@ -35,7 +34,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: arduino/setup-protoc@v3
       - run: rustup show
       - uses: Swatinem/rust-cache@v2
       - name: Build
@@ -48,7 +46,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      - uses: arduino/setup-protoc@v3
       - run: rustup show
       - uses: Swatinem/rust-cache@v2
       - name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,12 @@ on:
     paths:
       - '**.rs'
       - '**.toml'
+      - '**.yml'
   pull_request:
     paths:
       - '**.rs'
       - '**.toml'
+      - '**.yml'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This PR remove unnecessary installation of `protoc`.